### PR TITLE
bumped lodash dependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1982,9 +1982,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash.includes": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "http-errors": "~1.6.3",
     "jsonwebtoken": "^8.5.1",
     "knex": "^0.17.6",
+    "lodash": ">=4.17.14",
     "morgan": "~1.9.1",
     "mysql": "^2.17.1",
     "nodemailer": "^6.3.0",


### PR DESCRIPTION
Fixed vulnerability / security issues [CVE-2019-10744](https://github.com/lodash/lodash/pull/4336)